### PR TITLE
Bugfix - Update Property Category Range

### DIFF
--- a/src/zamnuts/EANAPIClient/Query/EANHotelList.php
+++ b/src/zamnuts/EANAPIClient/Query/EANHotelList.php
@@ -725,7 +725,7 @@ class EANHotelList extends EANAbstractQuery {
 	protected function get__propertyCategoryArray() {
 		$propertyCategoryList = $this->propertyCategoryList;
 		if ( !count($propertyCategoryList) ) {
-			$this->propertyCategoryList = range(1,7);
+			$this->propertyCategoryList = range(1,6);
 		}
 		return $this->propertyCategoryList;
 	}


### PR DESCRIPTION
We've been getting this:

![image](https://user-images.githubusercontent.com/8619663/36175922-ffe03868-10de-11e8-9839-ef65b94f8126.png)

According the docs propertyCategory only accepts a range of ints from 1-6, not 1-7. 
[https://support.ean.com/hc/en-us/articles/115005464729-V3-Hotel-List#propertyCategory](https://support.ean.com/hc/en-us/articles/115005464729-V3-Hotel-List#propertyCategory)

Unclear as to when this changed on their end. We are waiting to hear back from expedia.
[https://support.ean.com/hc/en-us/requests/351239](https://support.ean.com/hc/en-us/requests/351239)